### PR TITLE
Fix rank command reporting rank with banned people

### DIFF
--- a/src/cogs/levels.py
+++ b/src/cogs/levels.py
@@ -346,7 +346,7 @@ class Levels(commands.Cog):
         xp, level = result[0]
         rank: int = (
             await async_db_execute(
-                "SELECT COUNT(*)+1 FROM LEVELS WHERE XP > ?",
+                "SELECT COUNT(*)+1 FROM LEVELS WHERE XP > ? AND hidden=FALSE",
                 (xp,),
             )
         )[0][0]


### PR DESCRIPTION
The rank command gives the incorrect rank since it doesn't exclude hidden users. This fixes that.